### PR TITLE
ipq40xx: Unique, consistent `label` properties for essportN

### DIFF
--- a/target/linux/ipq40xx/patches-4.19/702-dts-ipq4019-add-PHY-switch-nodes.patch
+++ b/target/linux/ipq40xx/patches-4.19/702-dts-ipq4019-add-PHY-switch-nodes.patch
@@ -67,19 +67,19 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
 +
 +				essport2: port@2 {
 +					reg = <2>;
-+					label = "lan3";
++					label = "lan2";
 +					phy-handle = <&ethphy1>;
 +				};
 +
 +				essport3: port@3 {
 +					reg = <3>;
-+					label = "lan2";
++					label = "lan3";
 +					phy-handle = <&ethphy2>;
 +				};
 +
 +				essport4: port@4 {
 +					reg = <4>;
-+					label = "lan1";
++					label = "lan4";
 +					phy-handle = <&ethphy3>;
 +				};
 +


### PR DESCRIPTION
Early versions of this patch had duplicate `label` properties
leading to failure to initialize one of the ports.

Signed-off-by: Jeff Kletsky <git-commits@allycomm.com>

---

With this patch, all five now properly initialize
```
[    3.958484] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.959770] qca8k c000000.ess-switch lan1 (uninitialized): PHY [90000.mdio:00] driver [Generic PHY]
[    3.966121] qca8k c000000.ess-switch lan2 (uninitialized): PHY [90000.mdio:01] driver [Generic PHY]
[    3.974887] qca8k c000000.ess-switch lan3 (uninitialized): PHY [90000.mdio:02] driver [Generic PHY]
[    3.983853] qca8k c000000.ess-switch lan4 (uninitialized): PHY [90000.mdio:03] driver [Generic PHY]
[    3.992876] qca8k c000000.ess-switch wan (uninitialized): PHY [90000.mdio:04] driver [Generic PHY]
[    4.001101] DSA: tree 0 setup
```
resolving the duplicate error (-17) previously seen
```
[    3.530985] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.532496] qca8k c000000.ess-switch lan1 (uninitialized): PHY [90000.mdio:00] driver [Generic PHY]
[    3.538669] qca8k c000000.ess-switch lan3 (uninitialized): PHY [90000.mdio:01] driver [Generic PHY]
[    3.547318] qca8k c000000.ess-switch lan2 (uninitialized): PHY [90000.mdio:02] driver [Generic PHY]
[    3.556401] qca8k c000000.ess-switch lan1 (uninitialized): PHY [90000.mdio:03] driver [Generic PHY]
[    3.563739] ess-edma c080000.edma eth0: error -17 registering interface lan1
[    3.573169] qca8k c000000.ess-switch: failed to create slave for port 0.4
[    3.580792] qca8k c000000.ess-switch wan (uninitialized): PHY [90000.mdio:04] driver [Generic PHY]
[    3.587519] DSA: tree 0 setup
```
