### PR TITLE
ipq40xx: 4.19: Update to use kmod-usb-dwc3-qcm

### DIFF
--- a/target/linux/ipq40xx/Makefile
+++ b/target/linux/ipq40xx/Makefile
@@ -8,16 +8,15 @@ CPU_TYPE:=cortex-a7
 CPU_SUBTYPE:=neon-vfpv4
 MAINTAINER:=John Crispin <john@phrozen.org>
 
-# TODO: drop kmod-usb-dwc3-of-simple when migrating to 4.19
 KERNEL_PATCHVER:=4.19
 
 KERNELNAME:=zImage Image dtbs
 
 include $(INCLUDE_DIR)/target.mk
 DEFAULT_PACKAGES += \
-	kmod-usb-dwc3-of-simple \
-	kmod-leds-gpio kmod-gpio-button-hotplug swconfig \
-	kmod-ath10k-ct wpad-basic \
-	kmod-usb3 kmod-usb-dwc3 ath10k-firmware-qca4019-ct
+	kmod-leds-gpio kmod-gpio-button-hotplug \
+	kmod-ath10k-ct ath10k-firmware-qca4019-ct \
+	wpad-basic \
+	kmod-usb3 kmod-usb-dwc3-qcm
 
 $(eval $(call BuildTarget))


### PR DESCRIPTION
Linux 4.19 OpenWrt replaces kmod-usb-dwc3-of-simple
with kmod-usb-dwc3-qcm for the ipq40xx

Update package selection accordingly

Remove TODO noting this in ipq40xx/target.mk

(Other targets unmodified)

Runtime-tested: Linksys EA8300

Signed-off-by: Jeff Kletsky <git-commits@allycomm.com>
